### PR TITLE
refactor: quiz-viewer nextjs dynamic-import 적용

### DIFF
--- a/src/components/quiz-viewer.tsx
+++ b/src/components/quiz-viewer.tsx
@@ -3,10 +3,6 @@ import AceEditor from 'react-ace'
 import 'ace-builds/src-noconflict/mode-mysql'
 import 'ace-builds/src-noconflict/theme-monokai'
 
-import { Skeleton } from '@/components/ui/skeleton'
-
-import { useCSR } from '@/hooks/use-csr'
-
 import { size } from '@/styles/size'
 
 interface Props {
@@ -14,19 +10,6 @@ interface Props {
 }
 
 export function QuizViewer({ value = '' }: Props) {
-  const isClient = useCSR()
-
-  if (!isClient) {
-    return (
-      <Skeleton
-        style={{
-          height: size.quizViewerHeight,
-          width: size.quizViewerWidth,
-        }}
-      />
-    )
-  }
-
   return (
     <AceEditor
       mode="mysql"

--- a/src/pages/chapter/[id]/index.tsx
+++ b/src/pages/chapter/[id]/index.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react'
 
+import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
 
 import { Copy } from 'lucide-react'
 import { toast } from 'sonner'
 
 import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
 import {
   Tooltip,
   TooltipContent,
@@ -14,11 +16,23 @@ import {
 } from '@/components/ui/tooltip'
 
 import { QuizInputForm } from '@/components/quiz-input-form'
-import QuizViewer from '@/components/quiz-viewer'
 
 import { useQuizInChapterQuery } from '@/hooks/query/use-quiz-in-chapter-query'
 
+import { size } from '@/styles/size'
+
 import BaseLayout from '@/layouts/base-layout'
+
+const QuizViewer = dynamic(() => import('@/components/quiz-viewer'), {
+  loading: () => (
+    <Skeleton
+      style={{
+        height: size.quizViewerHeight,
+        width: size.quizViewerWidth,
+      }}
+    />
+  ),
+})
 
 export default function ChapterQuizResolverPage() {
   const router = useRouter()

--- a/src/pages/single/[id]/index.tsx
+++ b/src/pages/single/[id]/index.tsx
@@ -1,13 +1,28 @@
+import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
 
 import { toast } from 'sonner'
 
+import { Skeleton } from '@/components/ui/skeleton'
+
 import { QuizInputForm } from '@/components/quiz-input-form'
-import QuizViewer from '@/components/quiz-viewer'
 
 import { useSingleQuizQuery } from '@/hooks/query/use-single-quiz-query'
 
+import { size } from '@/styles/size'
+
 import BaseLayout from '@/layouts/base-layout'
+
+const QuizViewer = dynamic(() => import('@/components/quiz-viewer'), {
+  loading: () => (
+    <Skeleton
+      style={{
+        height: size.quizViewerHeight,
+        width: size.quizViewerWidth,
+      }}
+    />
+  ),
+})
 
 export default function SingleQuizResolverPage() {
   const router = useRouter()


### PR DESCRIPTION
### dynamic import 적용 전

<img width="687" alt="01_no-dynamic" src="https://github.com/JibJiby/blank-sql/assets/24295703/cd7681cb-10e0-44df-841c-302025d8a618">

&nbsp;&nbsp;

### dynamic import 적용 후

<img width="597" alt="04_dynamic-import-with-loading 적용 강조" src="https://github.com/JibJiby/blank-sql/assets/24295703/a3fbb32c-7df8-44dc-87c0-e4c87c1d8f47">

&nbsp;&nbsp;

### 사이즈 비교

`chapter/[id]` : 326kb -> **192** kb
`single/[id]` : 320kb -> **186** kb

&nbsp;&nbsp;

