### PR TITLE
Feature/optimize react query cache

### DIFF
--- a/src/hooks/query/use-quiz-in-chapter-query.ts
+++ b/src/hooks/query/use-quiz-in-chapter-query.ts
@@ -14,7 +14,8 @@ export const useQuizInChapterQuery = (chapterId: string) => {
       return res.data
     },
     enabled: !!chapterId,
-    staleTime: time.MINUTE * 30,
+    staleTime: time.DAY,
+    cacheTime: Infinity,
     initialData: undefined,
   })
 

--- a/src/hooks/query/use-quiz-in-chapter-query.ts
+++ b/src/hooks/query/use-quiz-in-chapter-query.ts
@@ -1,4 +1,6 @@
-import { useQuery } from '@tanstack/react-query'
+import { useEffect } from 'react'
+
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { api } from '@/lib/axios'
 
@@ -7,6 +9,7 @@ import { Quiz } from '@/models/quiz'
 import { time } from './constants'
 
 export const useQuizInChapterQuery = (chapterId: string) => {
+  const queryClient = useQueryClient()
   const query = useQuery<Quiz[]>({
     queryKey: ['chapter', chapterId],
     queryFn: async () => {
@@ -18,6 +21,15 @@ export const useQuizInChapterQuery = (chapterId: string) => {
     cacheTime: Infinity,
     initialData: undefined,
   })
+
+  //
+  useEffect(() => {
+    if (query.data) {
+      for (const quiz of query.data) {
+        queryClient.setQueryData(['quizzes', quiz.id], quiz)
+      }
+    }
+  }, [query.data, queryClient])
 
   return query
 }

--- a/src/hooks/query/use-quiz-in-chapter-query.ts
+++ b/src/hooks/query/use-quiz-in-chapter-query.ts
@@ -13,8 +13,16 @@ export const useQuizInChapterQuery = (chapterId: string) => {
   const query = useQuery<Quiz[]>({
     queryKey: ['chapter', chapterId],
     queryFn: async () => {
-      const res = await api.get(`/chapter/${chapterId}`)
-      return res.data
+      try {
+        const res = await api.get(`/chapter/${chapterId}`)
+        return res.data
+      } catch (err) {
+        console.error(err)
+        throw err
+      }
+    },
+    meta: {
+      errorMessage: '해당 챕터의 퀴즈를 불러오는데 오류가 발생했습니다',
     },
     enabled: !!chapterId,
     staleTime: time.DAY,
@@ -22,7 +30,6 @@ export const useQuizInChapterQuery = (chapterId: string) => {
     initialData: undefined,
   })
 
-  //
   useEffect(() => {
     if (query.data) {
       for (const quiz of query.data) {

--- a/src/hooks/query/use-single-quiz-query.ts
+++ b/src/hooks/query/use-single-quiz-query.ts
@@ -10,8 +10,16 @@ export const useSingleQuizQuery = (quizId: string) => {
   const query = useQuery<Quiz>({
     queryKey: ['quizzes', quizId],
     queryFn: async () => {
-      const res = await api(`/quiz/${quizId}`)
-      return res.data
+      try {
+        const res = await api(`/quiz/${quizId}`)
+        return res.data
+      } catch (err) {
+        console.error(err)
+        throw err
+      }
+    },
+    meta: {
+      errorMessage: '퀴즈 데이터를 서버로부터 가져오지 못했습니다.',
     },
     enabled: quizId !== undefined,
     staleTime: time.DAY,

--- a/src/hooks/query/use-single-quiz-query.ts
+++ b/src/hooks/query/use-single-quiz-query.ts
@@ -4,6 +4,8 @@ import { api } from '@/lib/axios'
 
 import { Quiz } from '@/models/quiz'
 
+import { time } from './constants'
+
 export const useSingleQuizQuery = (quizId: string) => {
   const query = useQuery<Quiz>({
     queryKey: ['quizzes', quizId],
@@ -12,6 +14,8 @@ export const useSingleQuizQuery = (quizId: string) => {
       return res.data
     },
     enabled: quizId !== undefined,
+    staleTime: time.DAY,
+    cacheTime: Infinity,
     initialData: undefined,
   })
 

--- a/src/lib/query.ts
+++ b/src/lib/query.ts
@@ -1,4 +1,5 @@
-import { QueryClient } from '@tanstack/react-query'
+import { QueryCache, QueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
 
 export const queryClient = new QueryClient({
   defaultOptions: {
@@ -7,4 +8,19 @@ export const queryClient = new QueryClient({
       refetchOnMount: false,
     },
   },
+  queryCache: new QueryCache({
+    // ref : https://tkdodo.eu/blog/react-query-error-handling#the-global-callbacks
+    onError: (error, query) => {
+      // TODO: 추후 에러 따로 적재
+      // ex) sentry
+      // console.error(error)
+
+      // 유저를 위한 UI 에러 피드백
+      if (query.meta?.errorMessage) {
+        toast.error(query.meta.errorMessage as string, {
+          duration: 2000,
+        })
+      }
+    },
+  }),
 })

--- a/src/pages/single/index.tsx
+++ b/src/pages/single/index.tsx
@@ -10,6 +10,7 @@ import { Input } from '@/components/ui/input'
 import TypographyH3 from '@/components/ui/typography/h3'
 
 import { api } from '@/lib/axios'
+import { queryClient } from '@/lib/query'
 
 import BaseLayout from '@/layouts/base-layout'
 
@@ -29,6 +30,12 @@ export default function SingleQuizPage() {
       return
     }
     const quizId = inputRef.current.value
+
+    const cachedQueryData = queryClient.getQueryData(['quizzes', quizId])
+    if (cachedQueryData) {
+      router.push(path + `/${quizId}`)
+      return
+    }
 
     try {
       await api.head(`/quiz/${quizId}`)

--- a/src/pages/single/index.tsx
+++ b/src/pages/single/index.tsx
@@ -2,6 +2,7 @@ import { KeyboardEvent, useEffect, useRef } from 'react'
 
 import { useRouter } from 'next/router'
 
+import { useQueryClient } from '@tanstack/react-query'
 import { AxiosError } from 'axios'
 import { toast } from 'sonner'
 
@@ -10,11 +11,11 @@ import { Input } from '@/components/ui/input'
 import TypographyH3 from '@/components/ui/typography/h3'
 
 import { api } from '@/lib/axios'
-import { queryClient } from '@/lib/query'
 
 import BaseLayout from '@/layouts/base-layout'
 
 export default function SingleQuizPage() {
+  const queryClient = useQueryClient()
   const router = useRouter()
   const inputRef = useRef<HTMLInputElement | null>(null)
 


### PR DESCRIPTION
### HTTP HEAD 요청 최소화

대상 페이지 : `/single`

&nbsp;

#### 코드 변화

* before

```tsx
try {
    await api.head(`/quiz/${quizId}`)
    router.push(path + `/${quizId}`)
  } catch (error) {
    if (error instanceof AxiosError) {
      if (error.response?.status === 404) {
        toast.error('입력하신 퀴즈 ID가 존재하지 않습니다.', {
          duration: 1000,
        })
      }
    }
  }
```

&nbsp;

* after

```tsx
const cachedQueryData = queryClient.getQueryData(['quizzes', quizId])
if (cachedQueryData) {
  router.push(path + `/${quizId}`)
  return
}

// ^^^^^^^^^^^^^^^^^^^^^^^ 코드 추가 부분

try {
    await api.head(`/quiz/${quizId}`)
    router.push(path + `/${quizId}`)
  } catch (error) {
    if (error instanceof AxiosError) {
      if (error.response?.status === 404) {
        toast.error('입력하신 퀴즈 ID가 존재하지 않습니다.', {
          duration: 1000,
        })
      }
    }
  }
```

&nbsp;&nbsp;

#### 네트워크 요청 및 queryCache

<img width="1256" alt="01_http-head-request" src="https://github.com/JibJiby/blank-sql/assets/24295703/97b7c286-e9e5-44c9-a95f-0191925faafb">

요청 전 queryCache 와 네트워크 히스토리 없는 상태

&nbsp;

<img width="1334" alt="02_http-head-request" src="https://github.com/JibJiby/blank-sql/assets/24295703/f0a22e44-c647-4356-876a-996268b590e2">

queryCache 에 없을 땐, HTTP `HEAD` 네트워크 요청함

&nbsp;

<img width="1211" alt="03_http-head-request" src="https://github.com/JibJiby/blank-sql/assets/24295703/268c9b50-1679-45cd-ba8c-0374b534ea85">

방금 전 생성된 quizId 로 검색을 진행한다면

&nbsp;

<img width="1191" alt="04_http-head-request" src="https://github.com/JibJiby/blank-sql/assets/24295703/652b1033-fa0a-4c0b-bf98-a58e0bebc146">

queryCache 에 캐싱되어 있을 때는 HTTP `HEAD` 네트워크 하지 않고 페이지 이동

&nbsp;&nbsp;

### chapter/[id] 데이터를 통한  quizzes 연쇄 캐싱 처리

대상 페이지 : `/chapter/[id]`

예를 들어, A 라는 챕터에 x, y 퀴즈가 있다면
queryCache 에 `['quizzes', x]` 와 `['quizzes', y]` 를 캐싱하여 퀴즈 검색시 요청 최소화

&nbsp;

<img width="1135" alt="01_setQueryData" src="https://github.com/JibJiby/blank-sql/assets/24295703/72a6c148-9fb7-48b2-b125-715b96620998">

요청 전 (queryCache 와 network 기록 ❌)

&nbsp;

<img width="1440" alt="02_setQueryData" src="https://github.com/JibJiby/blank-sql/assets/24295703/ef471156-00b8-40ab-8eda-316e27cfc8c2">

하나의 챕터 데이터 캐싱시, 퀴즈 데이터들도 연쇄적으로 캐싱됨

&nbsp;

<img width="1137" alt="03_setQueryData" src="https://github.com/JibJiby/blank-sql/assets/24295703/6a5198dd-f092-4b3d-9ff9-46b74682eded">

캐싱된 퀴즈 ID 로 검색한다면

&nbsp;

<img width="1216" alt="04_setQueryData" src="https://github.com/JibJiby/blank-sql/assets/24295703/fe531e2f-3a7c-40f3-8851-0ffbc0868deb">

HTTP 네트워크 요청 없이 캐싱 데이터 활용한 것을 확인할 수 있음

&nbsp;


